### PR TITLE
Fix "UserWarning: torch.meshgrid: in an upcoming release, it will be required to pass the indexing argument

### DIFF
--- a/models/yolo.py
+++ b/models/yolo.py
@@ -86,7 +86,7 @@ class Detect(nn.Module):
 
     @staticmethod
     def _make_grid(nx=20, ny=20):
-        yv, xv = torch.meshgrid([torch.arange(ny), torch.arange(nx)])
+        yv, xv = torch.meshgrid([torch.arange(ny), torch.arange(nx)], indexing='ij')
         return torch.stack((xv, yv), 2).view((1, 1, ny, nx, 2)).float()
 
 

--- a/utils/infer_utils.py
+++ b/utils/infer_utils.py
@@ -20,7 +20,7 @@ def decode_infer(output, stride):
 
     shiftx = torch.arange(0, gridsize, dtype=torch.float32)
     shifty = torch.arange(0, gridsize, dtype=torch.float32)
-    shifty, shiftx = torch.meshgrid([shiftx, shifty])
+    shifty, shiftx = torch.meshgrid([shiftx, shifty], indexing='ij')
     shiftx = shiftx.unsqueeze(-1).repeat(bz, 1, 1, self.gt_per_grid)
     shifty = shifty.unsqueeze(-1).repeat(bz, 1, 1, self.gt_per_grid)
 


### PR DESCRIPTION
By explicitly using indexing='ij' which is the current default Torch behavior.